### PR TITLE
prompt: rc.2-compatible fallback when getSectionOrder is unavailable

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -35,6 +35,17 @@ export const ZOTERO_PROMPT_ANCHOR = 'TOOL_REPORT' as const
 export const ZOTERO_PROMPT_ORDER_OFFSET = 100
 
 /**
+ * Fallback placement for harness lines without the runtime anchor lookup:
+ * dsh 0.1.1-rc.2 exposes no `systemPrompt.getSectionOrder()` and exports no
+ * anchor table — sections sort by plain numeric order and tool guidance
+ * lives in the 100-199 band. 106 is the proven 0.5.2-line placement (after
+ * the core tool sections, matching the released 0.5.1/0.5.2 policy slot).
+ * Kept as a named constant so the registration stays self-documenting and
+ * testable.
+ */
+export const ZOTERO_PROMPT_RC2_FALLBACK_ORDER = 106
+
+/**
  * The policy body with the configured tool caps interpolated — the values
  * the model must stay within, so out-of-range guesses fail before they hit
  * the validation step.
@@ -69,9 +80,18 @@ function zoteroPromptTextOf(
  * @param config - the live resolved config getter.
  */
 export function registerPromptSection(ctx: Context, config: () => ResolvedConfig): void {
+  // dsh >= 0.1.2-alpha.5 resolves the anchor at runtime. Older harness lines
+  // (e.g. 0.1.1-rc.2) have neither `getSectionOrder` nor any exported anchor
+  // table; registering there would throw at load, so fall back to the proven
+  // rc.2 band placement instead. On the alpha line this resolves to the same
+  // 3000 as before — behavior is unchanged.
+  const order =
+    typeof ctx.systemPrompt.getSectionOrder === 'function'
+      ? ctx.systemPrompt.getSectionOrder(ZOTERO_PROMPT_ANCHOR) + ZOTERO_PROMPT_ORDER_OFFSET
+      : ZOTERO_PROMPT_RC2_FALLBACK_ORDER
   ctx.systemPrompt.section({
     name: ZOTERO_PROMPT_SECTION_NAME,
-    order: ctx.systemPrompt.getSectionOrder(ZOTERO_PROMPT_ANCHOR) + ZOTERO_PROMPT_ORDER_OFFSET,
+    order,
     text: () => zoteroPromptTextOf(config()),
   })
 }


### PR DESCRIPTION
# prompt: 注册期对无 `getSectionOrder` 的 harness 线回退（rc.2 兼容桥）

## Summary

`registerPromptSection` 目前无条件调用 `ctx.systemPrompt.getSectionOrder(...)`。该运行时 API 只在
dsh `0.1.2-alpha.5+` 存在：在更早的 harness 线（如 `0.1.1-rc.2`，既无该方法、也不导出任何锚点表）上，
注册会在首个 assembly 抛错。此 PR 增加 `typeof` 守卫：alpha 线行为**完全不变**（仍解析为 3000），
老线回退到经过验证的 rc.2 落点 106。

> 本 PR 由 **dsh（DeepSeek Harness）自主构建并提交**；对应的发布线修复（v0.5.2-fixed）已由
> **提交者在本机实测**（dsh `0.1.1-rc.2`，web profile）：**不再因 dsh-zotero 导致 dsh web 启动失败**。

## Motivation / 背景

- 完整背景见 issue（#2）：`dsh-zotero@0.5.2` 在 rc.2 上因静态导入 `FIRST_PARTY_SECTION_ORDER` 无法加载；
  main 已改用 `getSectionOrder`（alpha.5 运行时 API），方向正确，但对缺少该 API 的 harness 版本会注册期崩溃。
- 本 PR 只解决“过渡版本注册崩溃”这一小步；**不是**对 main/0.6.0 的完整 rc.2 支持承诺
  （后者还受 `@deepseek-ai/dsh-util-values` 等 alpha 线专属依赖与 peer 范围限制，见 issue）。

## Changes

- `src/prompt.ts`：
  - 新增 `ZOTERO_PROMPT_RC2_FALLBACK_ORDER = 106`（带注释；rc.2 工具指导带 100–199，106 为 0.5.2 线上
    0.5.1 验证过的落点——与本仓库 0.5.2 发布物的行为一致）；
  - `registerPromptSection` 注册前先探测 `typeof ctx.systemPrompt.getSectionOrder === 'function'`，
    存在则维持原路径（`getSectionOrder('TOOL_REPORT') + 100` = 3000），缺失则用回退常量。

## Behavior matrix

| harness | 路径 | 结果 |
|---|---|---|
| dsh ≥ 0.1.2-alpha.5 | `getSectionOrder('TOOL_REPORT') + 100` | 3000（与现状一致）|
| dsh 0.1.1-rc.2（及无该 API 的过渡版）| 回退常量 | 106（0.5.1/0.5.2 发布线行为）|

## Validation

- 编译产物等价补丁（`lib/prompt.js` 命名空间导入双模式版）已在本机真实 rc.2 包环境
  （`@deepseek-ai/dsh-system-prompt@0.1.1-rc.2`）整链 ESM import 冒烟通过，回退值 = 106；
  对照原版精确复现加载报错。alpha 线数值路径与本 PR 改动前逐字节相同，故现有测试应不受影响；
  如需要，我可补充针对 `ZOTERO_PROMPT_RC2_FALLBACK_ORDER` 的单测。
- 本机无仓库测试工具链（vitest/tsc 依赖 alpha devDeps），未运行 upstream 测试套件——请维护者 CI 复核。

## Notes

- 未改动 peerDependencies/dshWorkshop 元数据：上游 alpha.5 定位保持不变；rc.2 侧安装时 peer 范围不满足仅告警
  （profile 装载器不强制 peer），如需无告警安装，0.5.2 线补丁（含 `^0.1.1-rc.2` peers）见关联 issue。
- 建议标题/分支可自行调整；也可仅作为 issue 的参考实现，由维护者决定是否合入。
- ⚠️ **后来者注意**：dsh `0.1.1-rc.2` 及更早版本的用户请勿直接安装 npm `dsh-zotero@0.5.2`/`0.6.x` 系列（详见关联 issue 的修复与版本对照）。
- **建议维护者在首页 README（README.md / README.en.md）标注**：最低支持的 dsh 版本，以及 section-order API 的版本变化提醒（0.5.2 起 `FIRST_PARTY_SECTION_ORDER`、0.6.0 起 `getSectionOrder`，rc.2 及更早均无），帮助后来者规避同类问题（详见关联 issue）。
